### PR TITLE
Add default platform name guessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.py[co]
 .*.sw[a-z]
 .coverage
+.coverage.*
 .idea
 .project
 .pydevproject

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ tests: test
 test: .venv.touch
 	tox $(REBUILD_FLAG)
 
+.PHONY: docker-tests
+docker-tests: .venv.touch
+	$(eval REBUILD_FLAG := -- tests --docker)
+	tox $(REBUILD_FLAG)
 
 .venv.touch: setup.py requirements-dev.txt
 	$(eval REBUILD_FLAG := --recreate)

--- a/README.md
+++ b/README.md
@@ -4,17 +4,31 @@
 pip-custom-platform
 ===================
 
-pip+wheel wrapper which allows you to choose a custom platform name for
-building, downloading, and installing wheels.
+[pip][pip]+[wheel][wheel] wrapper which allows you to choose a custom platform
+name for building, downloading, and installing wheels.
 
-This package assumes you're running your own pypi server and would like
+This package assumes you're running your own PyPI server and would like
 support for wheels on named platforms that would otherwise be considered
 equivalent by the wheel infrastructure (for example not all linux_x86_64 are
 created equal).
 
-pip: https://github.com/pypa/pip
+## Default platform names
 
-wheel: https://bitbucket.org/pypa/wheel
+By default, pip-custom-platform guesses a platform name for you based on the
+`platform` module for Linux, and uses the default platform name on Windows, OS
+X, or other systems. Some examples:
+
+| Platform                | Default Platform Name      |
+|-------------------------|----------------------------|
+| Ubuntu Trusty (14.04)   | linux_ubuntu_14_04_x86_64  |
+| Debian Jessie (8)       | linux_debian_8_x86_64      |
+| CentOS 7                | linux_centos_7_x86_64      |
+| Fedora 22               | linux_fedora_22_x86_64     |
+| Red Hat 7               | linux_rhel_7_x86_64        |
+| openSUSE 13.2           | linux_opensuse_13_x86_64   |
+
+You can choose your own platform name by passing `--platform my_platform` on
+the command line.
 
 ## Installation
 
@@ -33,3 +47,7 @@ wheel: https://bitbucket.org/pypa/wheel
 ### Installing packages
 
 `pip-custom-platform install --platform my-platform my-package`
+
+
+[pip]: https://github.com/pypa/pip
+[wheel]: https://bitbucket.org/pypa/wheel

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+def pytest_addoption(parser):
+    # The Docker tests are ridiculously slow (~1 hour), take a bunch of disk
+    # space, and are flaky by nature. So let's not run them by default (we have
+    # mocks as well as the Docker integration tests).
+    parser.addoption(
+        '--docker',
+        action='store_true',
+        default=False,
+        help='Run Docker tests (very slow, takes lots of disk space)',
+    )

--- a/pip_custom_platform/main.py
+++ b/pip_custom_platform/main.py
@@ -4,12 +4,16 @@ from __future__ import unicode_literals
 import argparse
 
 from pip_custom_platform.install import install
+from pip_custom_platform.util import default_platform_name
 from pip_custom_platform.wheel import wheel
 
 
 def add_shared_arguments(parser):
+    default_platform = default_platform_name()
     parser.add_argument(
-        '--platform', help='Custom platform name (required).', required=True,
+        '--platform',
+        default=default_platform,
+        help='Custom platform name (default: {0})'.format(default_platform),
     )
 
 

--- a/pip_custom_platform/util.py
+++ b/pip_custom_platform/util.py
@@ -3,8 +3,59 @@ from __future__ import unicode_literals
 
 import contextlib
 import os
+import platform
+import re
 import shutil
 import tempfile
+
+import distlib.wheel
+
+
+def default_platform_name():
+    """Guess a sane default platform name.
+
+    On OS X and Windows, just uses the default platform name. On Linux, uses
+    information from the `platform` module to try to make something reasonable.
+    """
+    def sanitize(string):
+        return re.sub('[^a-z0-9_]', '_', string.lower())
+
+    def grab_version(string, num):
+        """Grab the `num` most significant components of a version string.
+
+        >>> grab_version('12.04.1', 2)
+        '12.04'
+        >>> grab_version('8.2', 1)
+        '8'
+        """
+        return '.'.join(string.split('.')[:num])
+
+    if platform.system() == 'Linux':
+        dist, version, __ = platform.linux_distribution()
+        dist = re.sub('linux$', '', dist.lower()).strip()
+
+        if dist == 'red hat enterprise linux server':
+            dist = 'rhel'
+
+        # Try to determine a good "release" name. This is highly dependent on
+        # distribution and what guarantees they provide between versions.
+        release = None
+
+        if dist in ['debian', 'rhel', 'centos', 'fedora', 'opensuse']:
+            release = grab_version(version, 1)  # one version component
+        elif dist in ['ubuntu']:
+            release = grab_version(version, 2)  # two version components
+
+        if release:
+            return 'linux_{dist}_{release}_{arch}'.format(
+                dist=sanitize(dist),
+                release=sanitize(release),
+                arch=sanitize(platform.machine()),
+            )
+
+    # For Windows, OS X, or Linux distributions we couldn't identify, just fall
+    # back to whatever pip normally uses.
+    return distlib.wheel.ARCH
 
 
 @contextlib.contextmanager

--- a/tests/default_platform_test.py
+++ b/tests/default_platform_test.py
@@ -1,0 +1,152 @@
+from __future__ import print_function
+
+import sys
+from collections import namedtuple
+from os.path import dirname
+from os.path import realpath
+from subprocess import PIPE
+from subprocess import Popen
+
+import distlib.wheel
+import mock
+import pytest
+
+import pip_custom_platform
+from pip_custom_platform.util import default_platform_name
+
+
+SETUP_DEBIAN = (
+    'apt-get update -qq',
+    'DEBIAN_FRONTEND=noninteractive apt-get install -qq -y ' +
+    '    --no-install-recommends python python-pip >&2'
+)
+SETUP_NO_PIP_PACKAGE = (
+    # for systems with no pip system package (or RHEL which wants $$$$)
+    'curl "https://bootstrap.pypa.io/get-pip.py" | python >&2',
+)
+
+SystemTestCase = namedtuple('SystemTestCase', [
+    'docker_image',
+    'mock_linux_dist',
+    'expected_platform_name',
+    'setup_script',
+])
+
+SYSTEM_TESTCASES = [
+    SystemTestCase(
+        docker_image='ubuntu:trusty',
+        mock_linux_dist=('Ubuntu', '14.04', 'trusty'),
+        expected_platform_name='linux_ubuntu_14_04_x86_64',
+        setup_script=SETUP_DEBIAN,
+    ),
+    SystemTestCase(
+        docker_image='debian:jessie',
+        mock_linux_dist=('debian', '8.1', ''),
+        expected_platform_name='linux_debian_8_x86_64',
+        setup_script=SETUP_DEBIAN,
+    ),
+    SystemTestCase(
+        docker_image='centos:centos7',
+        mock_linux_dist=('CentOS Linux', '7.1.1503', 'Core'),
+        expected_platform_name='linux_centos_7_x86_64',
+        setup_script=SETUP_NO_PIP_PACKAGE,
+    ),
+    SystemTestCase(
+        docker_image='fedora:22',
+        mock_linux_dist=('Fedora', '22', 'Twenty Two'),
+        expected_platform_name='linux_fedora_22_x86_64',
+        setup_script=(
+            'yum install -y python-pip >&2',
+        )
+    ),
+    SystemTestCase(
+        docker_image='rhel7',
+        mock_linux_dist=('Red Hat Enterprise Linux Server', '7.1', 'Maipo'),
+        expected_platform_name='linux_rhel_7_x86_64',
+        setup_script=SETUP_NO_PIP_PACKAGE,
+    ),
+    SystemTestCase(
+        docker_image='opensuse:13.2',
+        mock_linux_dist=('openSUSE ', '13.2', 'x86_64'),
+        expected_platform_name='linux_opensuse_13_x86_64',
+        setup_script=(
+            'zypper --non-interactive install python python-pip >&2',
+        )
+    ),
+    SystemTestCase(
+        docker_image='base/archlinux',
+        mock_linux_dist=('arch', '', ''),
+        expected_platform_name='linux_x86_64',
+        setup_script=(
+            'pacman -Syy >&2',
+            'pacman -S --noconfirm python python-pip >&2',
+        )
+    ),
+]
+
+
+@pytest.mark.parametrize('case', SYSTEM_TESTCASES)
+@mock.patch('pip_custom_platform.util.platform')
+def test_platform_linux(mock_platform, case):
+    mock_platform.system.return_value = 'Linux'
+    mock_platform.machine.return_value = 'x86_64'
+    mock_platform.linux_distribution.return_value = case.mock_linux_dist
+    assert default_platform_name() == case.expected_platform_name
+
+
+@mock.patch('pip_custom_platform.util.platform')
+def test_platform_notlinux(mock_platform):
+    mock_platform.system.return_value = "it's a unix system!"
+    assert default_platform_name() == distlib.wheel.ARCH
+
+
+@pytest.mark.skipif(
+    'not config.getvalue("docker")',
+    reason="Requires --docker",
+)
+class TestDistributionNameDockerIntegration(object):  # pragma: no cover
+    """Launch Docker containers to test platform strings.
+
+    These tests are slow and take up a lot of disk space. They are only run if
+    `--docker` is passed to pytest on the command line.
+    """
+    # pylint: disable=no-self-use
+
+    @pytest.mark.parametrize('case', SYSTEM_TESTCASES)
+    def test_platform_name(self, case):
+        """Ensure the default_platform_name() output matches what we expect."""
+        commands = case.setup_script + (
+            'pip install /mnt >&2',
+            'python -c "from pip_custom_platform.util import default_platform_name\nprint(default_platform_name())"',  # noqa
+        )
+        stdout = run_in_docker(case.docker_image, commands)
+        assert stdout.strip() == case.expected_platform_name
+
+    @pytest.mark.parametrize('case', SYSTEM_TESTCASES)
+    def test_mock_is_accurate(self, case):
+        """Ensure our mocks for platform.linux_distribution() are accurate."""
+        commands = case.setup_script + (
+            'python -c "import platform\nprint(platform.linux_distribution())"',  # noqa
+        )
+        stdout = run_in_docker(case.docker_image, commands)
+        assert stdout.strip() == str(case.mock_linux_dist)
+
+
+def run_in_docker(image, commands):  # pragma: no cover
+    """Launches the Docker image and executes the commands, returning
+    stdout and stderr.
+
+    :param image: a Docker image and tag (e.g. 'debian:jessie')
+    :param commands: list of commands to paste to the shell
+    """
+    repo_dir = dirname(dirname(realpath(pip_custom_platform.__file__)))
+    mount_option = '{0}:/mnt:ro'.format(repo_dir)
+
+    cmd = ('docker', 'run', '-v', mount_option, '-i', image, 'sh')
+    proc = Popen(cmd, stdin=PIPE, stdout=PIPE)
+
+    lines = '\n'.join(commands)
+    if sys.version_info < (3,):
+        return proc.communicate(lines)[0]
+    else:
+        return proc.communicate(lines.encode('utf-8'))[0].decode('utf-8')


### PR DESCRIPTION
I feel kind of bad because you should be fishing instead of reviewing PRs. Feel free to wait until you get back to review this, there's no rush on it!

----

At `$JOB` we want the ability to have wheels for both an ancient version of Ubuntu and a slightly newer version of Ubuntu. The transition would be easier if we could just swap `pip` for `pip-custom-platform` without adding logic for guessing a platform name every place we install things.

Adding a guessed default would be convenient. The logic is basically:

* For non-Linux, use whatever pip uses already
* For Linux, use `platform.linux_distribution()` to try to guess a reasonable platform name.

Here are some examples (also added to the README):

| Platform                | Default Platform Name      |
|-------------------------|----------------------------|
| Ubuntu Trusty (14.04)   | linux_ubuntu_trusty_x86_64 |
| Debian Jessie (8)       | linux_debian_8_x86_64      |
| CentOS 7                | linux_centos_7_x86_64      |
| Fedora 22               | linux_fedora_22_x86_64     |
| Red Hat 7               | linux_rhel_7_x86_64        |
| openSUSE 13.2           | linux_opensuse_13_x86_64   |
| Arch Linux              | linux_arch_unknown_x86_64  |