### PR TITLE
Don't throw exception on Python3.4 with no args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /venv*
 coverage-html
 dist
+/.cache

--- a/pip_custom_platform/main.py
+++ b/pip_custom_platform/main.py
@@ -26,6 +26,7 @@ def main(argv=None):
         ),
     )
     subparsers = parser.add_subparsers(dest='command')
+    subparsers.required = True
 
     install_parser = subparsers.add_parser('install', help='Install packages')
     add_shared_arguments(install_parser)

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -33,6 +33,14 @@ def wheel(plat, wheeldir, pkg, *args):
     call('wheel', '--platform', plat, '--wheel-dir', wheeldir, pkg, *args)
 
 
+def test_useful_message_with_no_args():
+    """We should print a useful message when called with no arguments."""
+    with pytest.raises(CalledProcessError) as ex:
+        call()
+    _, _, stderr = ex.value.args
+    assert b'usage: main.py' in stderr
+
+
 def test_pure_python_package(tmpdir):
     wheeldir = tmpdir.join('wheelhouse').strpath
     wheel('plat', wheeldir, 'testing/pure_py_project')


### PR DESCRIPTION
This fixes https://github.com/asottile/pip-custom-platform/issues/3

New behavior:

### Python2.7 (unchanged)
```
usage: pip-custom-platform [-h] {install,wheel} ...
pip-custom-platform: error: too few arguments
```

### Python3.4
```
usage: pip-custom-platform [-h] {install,wheel} ...
pip-custom-platform: error: the following arguments are required: command
```