### PR TITLE
Fixed for Python 3.6 / pip 9.0.1 on Mac OS X 10.13.

### DIFF
--- a/pip_custom_platform/pymonkey.py
+++ b/pip_custom_platform/pymonkey.py
@@ -11,6 +11,11 @@ def pymonkey_patch(mod, args):
     if mod.__name__ == 'distutils.util':
         from pip_custom_platform.default_platform import get_platform_func
         mod.get_platform = get_platform_func(args, mod.get_platform)
+    elif mod.__name__ in ('pip.pep425tags', 'pip._internal.pep425tags'):
+        from pip_custom_platform.default_platform import get_platform_func
+        mod.get_platform = get_platform_func(args, mod.get_platform)
+        mod.supported_tags = mod.get_supported()
+        mod.supported_tags_noarch = mod.get_supported(noarch=True)
     elif mod.__name__ in ('pip', 'pip._internal') and hasattr(mod, 'main'):
         from pip_custom_platform._main import get_main
         mod.main = get_main(mod.main)


### PR DESCRIPTION
There was some Mac-specific code in pip that was causing issues with the `get_platform` monkey patch.

I'm not sure if I added the monkey patch for `sysconfig.get_platform` correctly (this is needed for Python 2.7 and >= 3.2, according to the pip source code, apparently). In any case, it seems to work!