### PR TITLE
Migrate from autopep8-wrapper to mirrors-autopep8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,20 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.2.3
+    rev: v2.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
-    -   id: autopep8-wrapper
     -   id: check-docstring-first
     -   id: check-yaml
     -   id: debug-statements
     -   id: name-tests-test
     -   id: requirements-txt-fixer
     -   id: flake8
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4
+    hooks:
+    -   id: autopep8
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.0.1
+    rev: v1.3.0
     hooks:
     -   id: reorder-python-imports

--- a/testing/uses_pip/uses_pip.py
+++ b/testing/uses_pip/uses_pip.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 try:  # pragma: no cover (pip>=10)
@@ -9,6 +10,7 @@ except ImportError:  # pragma: no cover (pip<10)
 def main():
     findlinks, download_dest, pkg, pkgname = sys.argv[1:]
     assert not pip_main(['wheel', pkg, '--wheel-dir', findlinks])
+    os.environ.pop('PIP_REQ_TRACKER', None)  # not reentrant
     assert not pip_main([
         'download',
         '--dest', download_dest,


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos