### PR TITLE
Pip>19 version support

### DIFF
--- a/pip_custom_platform/default_platform.py
+++ b/pip_custom_platform/default_platform.py
@@ -59,3 +59,22 @@ def get_platform_func(args, distutils_util_get_platform):
     else:
         platform_name = _default_platform_name(distutils_util_get_platform)
     return lambda: platform_name
+
+
+def get_multiple_platforms_func(args, underlying_function):
+    """
+    In pip>20, the underlying function's return type changed from a string, to
+    an iterable. As such, we need to match this when we perform the monkey
+    patch.
+
+    :type args: argparse.Namespace
+    :type underlying_function: Callable[[], Iterator[str]]
+    """
+    def wrapped():
+        for item in map(
+            lambda x: get_platform_func(args, lambda: x)(),
+            underlying_function(),
+        ):
+            yield item
+
+    return wrapped

--- a/pip_custom_platform/pymonkey.py
+++ b/pip_custom_platform/pymonkey.py
@@ -1,3 +1,20 @@
+# NOTE: These should be changed, depending on changes to pip's code layout
+# over time. This requires a `main` function.
+MAIN_MODULES = frozenset((
+    'pip',                      # pip < 10
+    'pip._internal',            # pip < 19.3
+    'pip._internal.main',       # pip < 20
+    'pip._internal.cli.main',   # pip ~ 20
+))
+
+# NOTE: This is a mapping between module_name, and function to monkey-patch.
+PEP425_MODULES = {
+    'pip.pep425tags': 'get_platform',               # pip < 9
+    'pip._internal.pep425tags': 'get_platform',     # pip < 20
+    'pip._vendor.packaging.tags': '_platform_tags'  # pip >= 20
+}
+
+
 def pymonkey_argparse(argv):
     # We want to parse --platform out as early as possible so we can do patches
     # based on it
@@ -21,14 +38,38 @@ def pymonkey_patch(module, args):
     if module.__name__ == 'distutils.util':
         from pip_custom_platform.default_platform import get_platform_func
         module.get_platform = get_platform_func(args, module.get_platform)
-    elif module.__name__ in ('pip.pep425tags', 'pip._internal.pep425tags'):
-        from pip_custom_platform.default_platform import get_platform_func
-        module.get_platform = get_platform_func(args, module.get_platform)
-        module.supported_tags = module.get_supported()
-        module.supported_tags_noarch = module.get_supported(noarch=True)
-    elif (
-        module.__name__ in ('pip', 'pip._internal') and
-        hasattr(module, 'main')
-    ):
+    elif module.__name__ in PEP425_MODULES:
+        _patch_pip_get_platform(module, args)
+    elif module.__name__ in MAIN_MODULES and hasattr(module, 'main'):
         from pip_custom_platform._main import get_main
         module.main = get_main(module.main)
+
+
+def _patch_pip_get_platform(module, args):
+    """
+    :type module: ModuleType
+    :type args: argparse.Namespace
+    """
+    function_name = PEP425_MODULES[module.__name__]
+    try:
+        underlying_function = getattr(module, function_name)
+    except AttributeError:
+        return
+
+    if isinstance(underlying_function(), str):
+        from pip_custom_platform.default_platform import get_platform_func
+        shimmed_function = get_platform_func
+    else:
+        from pip_custom_platform.default_platform import \
+            get_multiple_platforms_func
+        shimmed_function = get_multiple_platforms_func
+
+    setattr(
+        module,
+        function_name,
+        shimmed_function(args, underlying_function),
+    )
+
+    if hasattr(module, 'supported_tags'):
+        module.supported_tags = module.get_supported()
+        module.supported_tags_noarch = module.get_supported(noarch=True)

--- a/pip_custom_platform/pymonkey.py
+++ b/pip_custom_platform/pymonkey.py
@@ -53,10 +53,10 @@ def _patch_pip_get_platform(module, args):
     function_name = PEP425_MODULES[module.__name__]
     try:
         underlying_function = getattr(module, function_name)
-    except AttributeError:
+    except AttributeError:  # pragma: no cover
         return
 
-    if isinstance(underlying_function(), str):
+    if isinstance(underlying_function(), str):  # pragma: no cover
         from pip_custom_platform.default_platform import get_platform_func
         shimmed_function = get_platform_func
     else:
@@ -70,6 +70,6 @@ def _patch_pip_get_platform(module, args):
         shimmed_function(args, underlying_function),
     )
 
-    if hasattr(module, 'supported_tags'):
+    if hasattr(module, 'supported_tags'):   # pragma: no cover
         module.supported_tags = module.get_supported()
         module.supported_tags_noarch = module.get_supported(noarch=True)

--- a/pip_custom_platform/pymonkey.py
+++ b/pip_custom_platform/pymonkey.py
@@ -7,15 +7,28 @@ def pymonkey_argparse(argv):
     return parser.parse_known_args(argv)
 
 
-def pymonkey_patch(mod, args):
-    if mod.__name__ == 'distutils.util':
+def pymonkey_patch(module, args):
+    """
+    This is where the magic happens:
+        1. Monkey-patch `pip`'s `main` function, so that we can inject our own
+           custom parser. This allows us to provide additional functionality
+           (like `show-platform-name`) on top of the standard `pip` interface.
+
+        2. Monkey-patch `pip`'s default functionality to identify the platform
+           that the user is running on, and substitute it with our own (better)
+           platform parser.
+    """
+    if module.__name__ == 'distutils.util':
         from pip_custom_platform.default_platform import get_platform_func
-        mod.get_platform = get_platform_func(args, mod.get_platform)
-    elif mod.__name__ in ('pip.pep425tags', 'pip._internal.pep425tags'):
+        module.get_platform = get_platform_func(args, module.get_platform)
+    elif module.__name__ in ('pip.pep425tags', 'pip._internal.pep425tags'):
         from pip_custom_platform.default_platform import get_platform_func
-        mod.get_platform = get_platform_func(args, mod.get_platform)
-        mod.supported_tags = mod.get_supported()
-        mod.supported_tags_noarch = mod.get_supported(noarch=True)
-    elif mod.__name__ in ('pip', 'pip._internal') and hasattr(mod, 'main'):
+        module.get_platform = get_platform_func(args, module.get_platform)
+        module.supported_tags = module.get_supported()
+        module.supported_tags_noarch = module.get_supported(noarch=True)
+    elif (
+        module.__name__ in ('pip', 'pip._internal') and
+        hasattr(module, 'main')
+    ):
         from pip_custom_platform._main import get_main
-        mod.main = get_main(mod.main)
+        module.main = get_main(module.main)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,9 @@
 -e testing/uses_pip
 coverage
 mock
-# pip-custom-platform currently does not work with pip>=19.3
-pip<19.3
+pip
+pre-commit
 pytest
+tox
 # pypy's wheel tag changed in pip 20 / wheel 34
 wheel<0.34

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -32,7 +32,7 @@ def test_useful_message_with_no_args(capfd):
 
 def test_pure_python_package(tmpdir):
     wheeldir = tmpdir.join('wheelhouse').strpath
-    wheel('plat', wheeldir, 'testing/pure_py_project')
+    wheel('plat_64', wheeldir, 'testing/pure_py_project')
     assert os.listdir(wheeldir) == [
         'pure_python_project-0.1.0-py2.py3-none-any.whl',
     ]
@@ -40,27 +40,27 @@ def test_pure_python_package(tmpdir):
 
 def test_project_with_c(tmpdir):
     wheeldir = tmpdir.join('wheelhouse').strpath
-    wheel('plat', wheeldir, 'testing/project_with_c')
+    wheel('plat_64', wheeldir, 'testing/project_with_c')
     assert os.listdir(wheeldir) == [
-        expected_wheel_name('project_with_c-0.1.0-{}-{}-plat.whl'),
+        expected_wheel_name('project_with_c-0.1.0-{}-{}-plat_64.whl'),
     ]
 
 
 def test_multiple_platforms(tmpdir):
     wheeldir = tmpdir.join('wheelhouse').strpath
-    wheel('plat1', wheeldir, 'testing/project_with_c')
-    wheel('plat2', wheeldir, 'testing/project_with_c')
+    wheel('plat1_64', wheeldir, 'testing/project_with_c')
+    wheel('plat2_32', wheeldir, 'testing/project_with_c')
     assert set(os.listdir(wheeldir)) == {
-        expected_wheel_name('project_with_c-0.1.0-{}-{}-plat1.whl'),
-        expected_wheel_name('project_with_c-0.1.0-{}-{}-plat2.whl'),
+        expected_wheel_name('project_with_c-0.1.0-{}-{}-plat1_64.whl'),
+        expected_wheel_name('project_with_c-0.1.0-{}-{}-plat2_32.whl'),
     }
 
 
 def test_platform_with_dashes(tmpdir):
     wheeldir = tmpdir.join('wheelhouse').strpath
-    wheel('with-dashes', wheeldir, 'testing/project_with_c')
+    wheel('with-dashes_32', wheeldir, 'testing/project_with_c')
     assert os.listdir(wheeldir) == [
-        expected_wheel_name('project_with_c-0.1.0-{}-{}-with_dashes.whl'),
+        expected_wheel_name('project_with_c-0.1.0-{}-{}-with_dashes_32.whl'),
     ]
 
 
@@ -74,11 +74,11 @@ def test_download_smoke(tmpdir):
     download_dest = tmpdir.join('downloads').mkdir().strpath
 
     # Build a wheel that we'll install
-    wheel('plat1', findlinks_dir, 'testing/project_with_c')
+    wheel('plat1_64', findlinks_dir, 'testing/project_with_c')
 
     call(
         'download',
-        '--platform', 'plat1',
+        '--platform', 'plat1_64',
         '--dest', download_dest,
         '--find-links', 'file://{}'.format(findlinks_dir),
         '--no-index',
@@ -86,7 +86,7 @@ def test_download_smoke(tmpdir):
     )
 
     assert os.listdir(download_dest) == [
-        expected_wheel_name('project_with_c-0.1.0-{}-{}-plat1.whl'),
+        expected_wheel_name('project_with_c-0.1.0-{}-{}-plat1_64.whl'),
     ]
 
 
@@ -121,7 +121,7 @@ def test_download_falls_back_to_sdist(tmpdir):
 
     call(
         'download',
-        '--platform', 'plat1',
+        '--platform', 'plat1_64',
         '--dest', download_dest,
         '--find-links', 'file://{}'.format(findlinks_dir),
         '--no-index',
@@ -142,11 +142,11 @@ def test_download_wrong_plat_falls_back_to_sdist(tmpdir):
     )
 
     # Also build a wheel
-    wheel('plat2', findlinks_dir, 'testing/project_with_c')
+    wheel('plat2_64', findlinks_dir, 'testing/project_with_c')
 
     call(
         'download',
-        '--platform', 'plat1',
+        '--platform', 'plat1_32',
         '--dest', download_dest,
         '--find-links', 'file://{}'.format(findlinks_dir),
         '--no-index',
@@ -174,12 +174,12 @@ def test_pymonkey_patch(tmpdir):
 
     call_coverage(
         '-m', 'pymonkey', 'pip-custom-platform', '--', 'uses-pip',
-        '--platform', 'plat1',
+        '--platform', 'plat1_64',
         findlinks_dir, download_dest,
         'testing/project_with_c', 'project-with-c',
     )
     assert os.listdir(download_dest) == [
-        expected_wheel_name('project_with_c-0.1.0-{}-{}-plat1.whl'),
+        expected_wheel_name('project_with_c-0.1.0-{}-{}-plat1_64.whl'),
     ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ commands =
     coverage erase
     coverage run -m pytest {posargs:tests}
     coverage combine
-    coverage report --fail-under 100
+    coverage report --fail-under 100 --show-missing
 
 [testenv:latest_pip]
 commands =


### PR DESCRIPTION
I found myself digging through this repository to triage another issue, and I found that I understood the inner workings of this repository enough to fix this long standing issue (#32).

## Testing

I was able to install the package on all three pip versions tested, so seems successful to me.

### pip18

```bash
$ python -m venv pip18
$ source pip18/bin/activate
$ pip --version
pip 18.1 from /Users/aaronloo/Documents/github/pip-custom-platform/pip18/lib/python3.6/site-packages/pip (python 3.6)
$ pip install -e .
$ pip-custom-platform show-platform-name
linux_ubuntu_18_04_x86_64
$ pip-custom-platform install --no-cache-dir <internal-package>
```

### pip19

```bash
$ python -m venv pip19
$ source pip19/bin/activate
$ pip install --upgrade 'pip<20'
Collecting pip<20
  Using cached https://files.pythonhosted.org/packages/00/b6/9cfa56b4081ad13874b0c6f96af8ce16cfbc1cb06bedf8e9164ce5551ec1/pip-19.3.1-py2.py3-none-any.whl
Installing collected packages: pip
  Found existing installation: pip 18.1
    Uninstalling pip-18.1:
      Successfully uninstalled pip-18.1
Successfully installed pip-19.3.1
$ pip install -e .
$ pip-custom-platform show-platform-name
linux_ubuntu_18_04_x86_64
$ pip-custom-platform install --no-cache-dir <internal-package>
```

### pip20

```bash
$ virtualenv --python=python3 pip20
$ source pip20/bin/activate
$ pip --version
pip 20.0.2 from /Users/aaronloo/Documents/github/pip-custom-platform/pip20/lib/python3.6/site-packages/pip (python 3.6)
$ pip-custom-platform show-platform-name
linux_ubuntu_18_04_x86_64
$ pip-custom-platform install --no-cache-dir <internal-package>
```